### PR TITLE
Allow the embedding of charts on other websites

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -29,3 +29,6 @@ src/semantic/tasks
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# settings
+/src/config/settings.js

--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "start": "node scripts/start.js",
-    "build": "node scripts/build.js",
+    "build": "cp -n src/config/settings.template.js src/config/settings.js && node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom",
     "lint": "eslint src/",
     "lint-fix": "eslint src/ --fix"

--- a/client/src/actions/chart.js
+++ b/client/src/actions/chart.js
@@ -248,3 +248,25 @@ export function testQuery(projectId, data) {
       });
   };
 }
+
+export function getEmbeddedChart(id) {
+  return () => {
+    const url = `${API_HOST}/chart/${id}/embedded`;
+    const method = "GET";
+    const headers = new Headers({
+      "Accept": "application/json",
+    });
+
+    return fetch(url, { method, headers })
+      .then((response) => {
+        if (!response.ok) {
+          return Promise.reject(response.status);
+        }
+
+        return response.json();
+      })
+      .then((chart) => {
+        return Promise.resolve(chart);
+      });
+  };
+}

--- a/client/src/config/settings.template.js
+++ b/client/src/config/settings.template.js
@@ -1,2 +1,3 @@
 export const API_HOST = process.env.NODE_ENV === "production" ? "https://api.chartbrew.com" : "http://localhost:3210";
 export const DOCUMENTATION_HOST = process.env.NODE_ENV === "production" ? "https://docs.chartbrew.com" : "http://localhost:8080";
+export const SITE_HOST = process.env.NODE_ENV === "production" ? "https://chartbrew.com" : "http://localhost:3000";

--- a/client/src/containers/Chart.js
+++ b/client/src/containers/Chart.js
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { withRouter } from "react-router";
 import {
   Card, Icon, Header, Grid, Segment, Dimmer, Loader, Modal, Button,
-  Dropdown, Message, Popup, Form,
+  Dropdown, Message, Popup, Form, TextArea,
 } from "semantic-ui-react";
 import {
   Line, Bar, Pie, Doughnut, Radar, Polar
@@ -17,9 +17,10 @@ import {
   removeChart, runQuery, updateChart, changeOrder
 } from "../actions/chart";
 import canAccess from "../config/canAccess";
+import { SITE_HOST } from "../config/settings";
 
 /*
-  Description
+  This is the container that generates the Charts together with the menu
 */
 class Chart extends Component {
   constructor(props) {
@@ -124,6 +125,10 @@ class Chart extends Component {
       });
   }
 
+  _onEmbed = (chart) => {
+    this.setState({ selectedChart: chart, embedModal: true });
+  }
+
   _openUpdateModal = (chart) => {
     this.setState({ updateModal: true, selectedChart: chart, updateFrequency: chart.autoUpdate });
   }
@@ -172,8 +177,8 @@ class Chart extends Component {
     } = this.props;
     const { projectId } = match.params;
     const {
-      error, chartLoading, deleteModal, publicModal, publicLoading,
-      updateModal, updateFrequency, autoUpdateLoading,
+      error, chartLoading, deleteModal, publicModal, publicLoading, embedModal,
+      updateModal, updateFrequency, autoUpdateLoading, selectedChart,
     } = this.state;
 
     return (
@@ -244,6 +249,11 @@ class Chart extends Component {
                           <Icon name="world" color={chart.public ? "red" : "green"} />
                           {chart.public ? "Make private" : "Make public"}
                         </Dropdown.Item>
+                        <Dropdown.Item
+                          icon="code"
+                          text="Embed"
+                          onClick={() => this._onEmbed(chart)}
+                        />
                         <Dropdown.Divider />
                         <Dropdown
                           item
@@ -535,6 +545,63 @@ class Chart extends Component {
             </Button>
           </Modal.Actions>
         </Modal>
+
+        {/* EMBED CHART MODAL */}
+        {selectedChart && (
+          <Modal
+            open={embedModal}
+            basic
+            size="small"
+            onClose={() => this.setState({ embedModal: false })}
+          >
+            <Header
+              icon="code"
+              content="Embed your chart on other websites"
+            />
+            <Modal.Content>
+              <p>
+                {"Copy the following code on the website you wish to add your chart in. You can add other iframe settings if you wish so."}
+              </p>
+              <Form>
+                <TextArea
+                  value={`<iframe src="${SITE_HOST}/chart/${selectedChart.id}/embedded" allowTransparency="true"></iframe>`}
+                />
+              </Form>
+            </Modal.Content>
+            <Modal.Actions>
+              {selectedChart.public && (
+                <Button
+                  basic
+                  inverted
+                  onClick={() => this.setState({ embedModal: false })}
+                >
+                  Done
+                </Button>
+              )}
+              {!selectedChart.public && (
+                <Button
+                  basic
+                  inverted
+                  onClick={() => this.setState({ embedModal: false })}
+                >
+                  Cancel
+                </Button>
+              )}
+              {!selectedChart.public && (
+                <Button
+                  color="teal"
+                  inverted
+                  onClick={() => {
+                    this._onPublic();
+                    this.setState({ embedModal: false });
+                  }}
+                >
+                  Make public
+                </Button>
+              )}
+            </Modal.Actions>
+          </Modal>
+        )}
       </div>
     );
   }

--- a/client/src/containers/Chart.js
+++ b/client/src/containers/Chart.js
@@ -560,11 +560,14 @@ class Chart extends Component {
             />
             <Modal.Content>
               <p>
-                {"Copy the following code on the website you wish to add your chart in. You can add other iframe settings if you wish so."}
+                {"Copy the following code on the website you wish to add your chart in."}
+              </p>
+              <p>
+                {"You can customize the iframe in any way you wish, but leave the 'src' attribute the way it is below."}
               </p>
               <Form>
                 <TextArea
-                  value={`<iframe src="${SITE_HOST}/chart/${selectedChart.id}/embedded" allowTransparency="true"></iframe>`}
+                  value={`<iframe src="${SITE_HOST}/chart/${selectedChart.id}/embedded" allowTransparency="true" width="700" height="300" scrolling="no" frameborder="0"></iframe>`}
                 />
               </Form>
             </Modal.Content>

--- a/client/src/containers/EmbeddedChart.js
+++ b/client/src/containers/EmbeddedChart.js
@@ -7,7 +7,6 @@ import {
 import {
   Container, Loader, Header, Image, Message,
 } from "semantic-ui-react";
-import moment from "moment";
 
 import logo from "../assets/cb_logo_4_small.png";
 

--- a/client/src/containers/EmbeddedChart.js
+++ b/client/src/containers/EmbeddedChart.js
@@ -9,7 +9,6 @@ import {
 } from "semantic-ui-react";
 import moment from "moment";
 
-import "../embedded.css";
 import logo from "../assets/cb_logo_4_small.png";
 
 import { getEmbeddedChart as getEmbeddedChartAction } from "../actions/chart";
@@ -28,6 +27,9 @@ class EmbeddedChart extends Component {
   }
 
   componentDidMount() {
+    // change the background color to transparent
+    document.body.style.backgroundColor = "transparent";
+
     const { getEmbeddedChart, match } = this.props;
 
     this.setState({ loading: true });

--- a/client/src/containers/EmbeddedChart.js
+++ b/client/src/containers/EmbeddedChart.js
@@ -24,7 +24,6 @@ class EmbeddedChart extends Component {
     this.state = {
       loading: false,
       chart: null,
-      error: true,
     };
   }
 

--- a/client/src/containers/EmbeddedChart.js
+++ b/client/src/containers/EmbeddedChart.js
@@ -13,6 +13,8 @@ import logo from "../assets/cb_logo_4_small.png";
 
 import { getEmbeddedChart as getEmbeddedChartAction } from "../actions/chart";
 
+const pageHeight = window.innerHeight;
+
 /*
   This container is used for embedding charts in other websites
 */
@@ -86,51 +88,63 @@ class EmbeddedChart extends Component {
           </Container>
           {chart.type === "line"
           && (
-          <Line
-            data={chart.chartData.data}
-            options={chart.chartData.options}
-            height={300}
-          />
+          <Container fluid>
+            <Line
+              data={chart.chartData.data}
+              options={chart.chartData.options}
+              responsive
+            />
+          </Container>
           )}
           {chart.type === "bar"
           && (
-          <Bar
-            data={chart.chartData.data}
-            options={chart.chartData.options}
-            height={300}
-          />
+          <Container fluid>
+            <Bar
+              data={chart.chartData.data}
+              options={chart.chartData.options}
+              height={pageHeight - 100}
+            />
+          </Container>
           )}
           {chart.type === "pie"
           && (
-          <Pie
-            data={chart.chartData.data}
-            options={chart.chartData.options}
-            height={300}
-          />
+          <Container fluid>
+            <Pie
+              data={chart.chartData.data}
+              options={chart.chartData.options}
+              height={pageHeight - 100}
+            />
+          </Container>
           )}
           {chart.type === "doughnut"
           && (
-          <Doughnut
-            data={chart.chartData.data}
-            options={chart.chartData.options}
-            height={300}
-          />
+          <Container fluid>
+            <Doughnut
+              data={chart.chartData.data}
+              options={chart.chartData.options}
+              height={pageHeight - 100}
+            />
+          </Container>
           )}
           {chart.type === "radar"
           && (
-          <Radar
-            data={chart.chartData.data}
-            options={chart.chartData.options}
-            height={300}
-          />
+          <Container fluid>
+            <Radar
+              data={chart.chartData.data}
+              options={chart.chartData.options}
+              height={pageHeight - 100}
+            />
+          </Container>
           )}
           {chart.type === "polar"
           && (
-          <Polar
-            data={chart.chartData.data}
-            options={chart.chartData.options}
-            height={300}
-          />
+          <Container fluid>
+            <Polar
+              data={chart.chartData.data}
+              options={chart.chartData.options}
+              height={pageHeight - 100}
+            />
+          </Container>
           )}
           <p style={styles.updatedText}>
             <small>

--- a/client/src/containers/EmbeddedChart.js
+++ b/client/src/containers/EmbeddedChart.js
@@ -92,7 +92,7 @@ class EmbeddedChart extends Component {
             <Line
               data={chart.chartData.data}
               options={chart.chartData.options}
-              responsive
+              height={pageHeight - 100}
             />
           </Container>
           )}
@@ -146,11 +146,6 @@ class EmbeddedChart extends Component {
             />
           </Container>
           )}
-          <p style={styles.updatedText}>
-            <small>
-              <i>{`Last Updated ${moment(chart.chartDataUpdated).calendar()}`}</i>
-            </small>
-          </p>
         </Container>
       </div>
     );

--- a/client/src/containers/EmbeddedChart.js
+++ b/client/src/containers/EmbeddedChart.js
@@ -1,0 +1,183 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import {
+  Line, Bar, Pie, Doughnut, Radar, Polar
+} from "react-chartjs-2";
+import {
+  Container, Loader, Header, Image, Message,
+} from "semantic-ui-react";
+import moment from "moment";
+
+import "../embedded.css";
+import logo from "../assets/cb_logo_4_small.png";
+
+import { getEmbeddedChart as getEmbeddedChartAction } from "../actions/chart";
+
+/*
+  This container is used for embedding charts in other websites
+*/
+class EmbeddedChart extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: false,
+      chart: null,
+      error: true,
+    };
+  }
+
+  componentDidMount() {
+    const { getEmbeddedChart, match } = this.props;
+
+    this.setState({ loading: true });
+    setTimeout(() => {
+      getEmbeddedChart(match.params.chartId)
+        .then((chart) => {
+          this.setState({
+            chart,
+            loading: false,
+          });
+        })
+        .catch(() => {
+          this.setState({
+            error: true,
+            loading: false,
+            chart: { error: "no chart" },
+          });
+        });
+    }, 1000);
+  }
+
+  render() {
+    const { loading, error, chart } = this.state;
+
+    if (loading || !chart) {
+      return (
+        <Container textAlign="center" text style={styles.loaderContainer}>
+          <Loader active inverted>Loading</Loader>
+        </Container>
+      );
+    }
+
+    if (error) {
+      return (
+        <Container text>
+          <Message>
+            <Message.Header>Error loading the Chart</Message.Header>
+            <p>
+              The Chart might not be public in the ChartBrew dashboard.
+            </p>
+          </Message>
+        </Container>
+      );
+    }
+
+    return (
+      <div style={styles.container}>
+        <Container>
+          <Container fluid style={styles.header}>
+            <a href="https://chartbrew.com" target="_parent" title="Powered by ChartBrew">
+              <Image src={logo} size="mini" style={styles.logo} />
+            </a>
+            <Header>{chart.name}</Header>
+          </Container>
+          {chart.type === "line"
+          && (
+          <Line
+            data={chart.chartData.data}
+            options={chart.chartData.options}
+            height={300}
+          />
+          )}
+          {chart.type === "bar"
+          && (
+          <Bar
+            data={chart.chartData.data}
+            options={chart.chartData.options}
+            height={300}
+          />
+          )}
+          {chart.type === "pie"
+          && (
+          <Pie
+            data={chart.chartData.data}
+            options={chart.chartData.options}
+            height={300}
+          />
+          )}
+          {chart.type === "doughnut"
+          && (
+          <Doughnut
+            data={chart.chartData.data}
+            options={chart.chartData.options}
+            height={300}
+          />
+          )}
+          {chart.type === "radar"
+          && (
+          <Radar
+            data={chart.chartData.data}
+            options={chart.chartData.options}
+            height={300}
+          />
+          )}
+          {chart.type === "polar"
+          && (
+          <Polar
+            data={chart.chartData.data}
+            options={chart.chartData.options}
+            height={300}
+          />
+          )}
+          <p style={styles.updatedText}>
+            <small>
+              <i>{`Last Updated ${moment(chart.chartDataUpdated).calendar()}`}</i>
+            </small>
+          </p>
+        </Container>
+      </div>
+    );
+  }
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    backgroundColor: "transparent",
+  },
+  header: {
+    paddingRight: 20,
+    paddingLeft: 20,
+  },
+  loaderContainer: {
+    minHeight: 100,
+    minWidth: 100,
+  },
+  logo: {
+    float: "right",
+    opacity: 0.5,
+  },
+  updatedText: {
+    paddingLeft: 20,
+  },
+};
+
+EmbeddedChart.propTypes = {
+  getEmbeddedChart: PropTypes.func.isRequired,
+  match: PropTypes.object.isRequired,
+};
+
+const mapStateToProps = () => {
+  return {
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    getEmbeddedChart: (id) => dispatch(getEmbeddedChartAction(id)),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(EmbeddedChart);

--- a/client/src/containers/Main.js
+++ b/client/src/containers/Main.js
@@ -15,6 +15,7 @@ import ManageUser from "./ManageUser";
 import FeedbackForm from "../components/FeedbackForm";
 import PublicDashboard from "./PublicDashboard";
 import PasswordReset from "./PasswordReset";
+import EmbeddedChart from "./EmbeddedChart";
 
 import { relog, getUser } from "../actions/user";
 import { getTeams } from "../actions/team";
@@ -73,6 +74,7 @@ class Main extends Component {
             <Route exact path="/:teamId/:projectId/members" component={ProjectBoard} />
             <Route exact path="/:teamId/:projectId/settings" component={ProjectBoard} />
             <Route exact path="/:teamId/:projectId/public" component={ProjectBoard} />
+            <Route exact path="/chart/:chartId/embedded" component={EmbeddedChart} />
           </Switch>
         </div>
       </div>

--- a/client/src/containers/Main.js
+++ b/client/src/containers/Main.js
@@ -26,14 +26,16 @@ import { getAllProjects } from "../actions/project";
 class Main extends Component {
   componentWillMount() {
     const {
-      relog, getUser, getTeams, getAllProjects,
+      relog, getUser, getTeams, getAllProjects, location,
     } = this.props;
 
-    relog().then((data) => {
-      getUser(data.id);
-      getTeams(data.id);
-      return getAllProjects();
-    });
+    if (!location.pathname.match(/\/chart\/\d+\/embedded/g)) {
+      relog().then((data) => {
+        getUser(data.id);
+        getTeams(data.id);
+        return getAllProjects();
+      });
+    }
   }
 
   render() {
@@ -93,6 +95,7 @@ Main.propTypes = {
   getUser: PropTypes.func.isRequired,
   getTeams: PropTypes.func.isRequired,
   getAllProjects: PropTypes.func.isRequired,
+  location: PropTypes.object.isRequired,
   // user: PropTypes.object.isRequired,
 };
 

--- a/client/src/embedded.css
+++ b/client/src/embedded.css
@@ -1,3 +1,0 @@
-body {
-  background-color: transparent !important;
-}

--- a/client/src/embedded.css
+++ b/client/src/embedded.css
@@ -1,0 +1,3 @@
+body {
+  background-color: transparent !important;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,20 @@ module.exports = {
 };
 ```
 
+### Setting up the frontend settings
+
+```sh
+cp client/src/config/settings.template.js client/src/config/settings.js
+```
+
+Modify the constants to match your environment.
+
+`API_HOST` - where your API is running
+
+`DOCUMENTATION_HOST` - in case you're running the documentation somewhere on your server (you can also leave it to the live ChartBrew one)
+
+`SITE_HOST` - this is where your frontend is sitting
+
 ### Run the project in Development
 
 Open two terminals, one for front-end and the other for back-end.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chartbrew",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "setup": "npm install && cd client && npm install && cd ../server/ && npm install",
+    "setup": "npm install && cd client && cp -n src/config/settings.template.js src/config/settings.js && npm install && cd ../server/ && npm install",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs"
   },

--- a/server/api/ChartRoute.js
+++ b/server/api/ChartRoute.js
@@ -238,6 +238,35 @@ module.exports = (app) => {
   });
   // --------------------------------------------------------
 
+
+  /*
+  ** Route to get a chart for embedding (must be public for success)
+  */
+  app.get("/chart/:id", (req, res) => {
+    return chartController.findById(req.params.id)
+      .then((chart) => {
+        if (!chart.public) throw new Error("401");
+
+        return res.status(200).send({
+          name: chart.name,
+          type: chart.type,
+          subType: chart.subType,
+          chartDataUpdated: chart.chartDataUpdated,
+          chartData: chart.chartData
+        });
+      })
+      .catch((error) => {
+        if (error.message === "401") {
+          return res.status(401).send({ error: "Not authorized" });
+        }
+        if (error.message.indexOf("413") > -1) {
+          return res.status(413).send(error);
+        }
+        return res.status(400).send(error);
+      });
+  });
+  // --------------------------------------------------------
+
   return (req, res, next) => {
     next();
   };

--- a/server/api/ChartRoute.js
+++ b/server/api/ChartRoute.js
@@ -242,7 +242,7 @@ module.exports = (app) => {
   /*
   ** Route to get a chart for embedding (must be public for success)
   */
-  app.get("/chart/:id", (req, res) => {
+  app.get("/chart/:id/embedded", (req, res) => {
     return chartController.findById(req.params.id)
       .then((chart) => {
         if (!chart.public) throw new Error("401");


### PR DESCRIPTION
### Chart embedding [New Feature] 💅

This will entail that CB will have separate pages for each chart that can be used to embed them in `<iframe/>`. So basically, `chartbrew.com/chart/6546/embed` can be embedded into another site with `<iframe src="above_url"></iframe>`.

The API can serve this data if the chart is public, so that will need to be specific in the front-end.

Getting the embedded code can be done through the menu of each of the charts on the dashboard.

- [x] New API route to get the data for embedding
- [x] Front-end changes - new embedded page and menu option
 