### PR TITLE
Introducing new Error handling in the client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "fs-extra": "3.0.1",
     "history": "^4.10.1",
     "html-webpack-plugin": "2.29.0",
+    "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",

--- a/client/src/actions/apiRequest.js
+++ b/client/src/actions/apiRequest.js
@@ -1,8 +1,9 @@
 import cookie from "react-cookies";
 import { API_HOST } from "../config/settings";
+import { addError } from "./error";
 
 export function getApiRequestByChart(projectId, chartId) {
-  return () => {
+  return (dispatch) => {
     const token = cookie.load("brewToken");
     const url = `${API_HOST}/project/${projectId}/chart/${chartId}/apiRequest`;
     const method = "GET";
@@ -14,6 +15,7 @@ export function getApiRequestByChart(projectId, chartId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status, "API request failed"));
           return new Promise((resolve, reject) => reject(response.status));
         }
 

--- a/client/src/actions/chart.js
+++ b/client/src/actions/chart.js
@@ -1,6 +1,7 @@
 import cookie from "react-cookies";
 
 import { API_HOST } from "../config/settings";
+import { addError } from "./error";
 
 export const FETCH_CHART = "FETCH_CHART";
 export const FETCH_ALL_CHARTS = "FETCH_ALL_CHARTS";
@@ -21,6 +22,7 @@ export function getProjectCharts(projectId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -52,6 +54,7 @@ export function createChart(projectId, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -84,6 +87,7 @@ export function updateChart(projectId, chartId, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -116,6 +120,7 @@ export function changeOrder(projectId, chartId, otherId) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -146,6 +151,7 @@ export function removeChart(projectId, chartId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -177,6 +183,7 @@ export function runQuery(projectId, chartId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.status));
         }
 
@@ -207,6 +214,7 @@ export function getPreviewData(projectId, chart) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -222,7 +230,7 @@ export function getPreviewData(projectId, chart) {
 }
 
 export function testQuery(projectId, data) {
-  return () => {
+  return (dispatch) => {
     const token = cookie.load("brewToken");
     const url = `${API_HOST}/project/${projectId}/chart/test`;
     const method = "POST";
@@ -236,6 +244,7 @@ export function testQuery(projectId, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.status));
         }
         return response.json();
@@ -250,7 +259,7 @@ export function testQuery(projectId, data) {
 }
 
 export function getEmbeddedChart(id) {
-  return () => {
+  return (dispatch) => {
     const url = `${API_HOST}/chart/${id}/embedded`;
     const method = "GET";
     const headers = new Headers({
@@ -260,6 +269,7 @@ export function getEmbeddedChart(id) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return Promise.reject(response.status);
         }
 

--- a/client/src/actions/connection.js
+++ b/client/src/actions/connection.js
@@ -2,6 +2,7 @@ import cookie from "react-cookies";
 
 import { API_HOST } from "../config/settings";
 import { getProject } from "./project";
+import { addError } from "./error";
 
 export const FETCHING_CONNECTION = "FETCHING_CONNECTION";
 export const FETCH_CONNECTION_SUCCESS = "FETCH_CONNECTION_SUCCESS";
@@ -25,6 +26,7 @@ export function getProjectConnections(projectId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -59,6 +61,7 @@ export function addConnection(projectId, connection) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error(response.status);
         }
 
@@ -94,6 +97,7 @@ export function saveConnection(projectId, connection) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error(response.status);
         }
 
@@ -111,7 +115,7 @@ export function saveConnection(projectId, connection) {
 }
 
 export function testConnection(projectId, id) {
-  return () => {
+  return (dispatch) => {
     if (!cookie.load("brewToken")) {
       return new Promise((resolve, reject) => reject(new Error("No Token")));
     }
@@ -126,6 +130,7 @@ export function testConnection(projectId, id) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -141,7 +146,7 @@ export function testConnection(projectId, id) {
 }
 
 export function testApiRequest(projectId, id, apiRequest) {
-  return () => {
+  return (dispatch) => {
     if (!cookie.load("brewToken")) {
       return new Promise((resolve, reject) => reject(new Error("No Token")));
     }
@@ -168,6 +173,7 @@ export function testApiRequest(projectId, id, apiRequest) {
         };
 
         if (!response.ok) {
+          dispatch(addError(status.statusCode, status.statusText));
           return new Promise((resolve, reject) => reject(status));
         }
 
@@ -205,6 +211,7 @@ export function updateConnection(projectId, id, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -221,7 +228,7 @@ export function updateConnection(projectId, id, data) {
 }
 
 export function removeConnection(projectId, id) {
-  return () => {
+  return (dispatch) => {
     if (!cookie.load("brewToken")) {
       return new Promise((resolve, reject) => reject(new Error("No Token")));
     }
@@ -236,6 +243,7 @@ export function removeConnection(projectId, id) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 

--- a/client/src/actions/error.js
+++ b/client/src/actions/error.js
@@ -1,0 +1,29 @@
+export const ADD_ERROR = "ADD_ERROR";
+export const REMOVE_ERROR = "REMOVE_ERROR";
+export const CLEAN_ERRORS = "CLEAN_ERRORS";
+
+export function addError(error) {
+  return (dispatch) => {
+    dispatch({
+      type: ADD_ERROR,
+      error,
+    });
+  };
+}
+
+export function removeError(index) {
+  return (dispatch) => {
+    dispatch({
+      type: REMOVE_ERROR,
+      index,
+    });
+  };
+}
+
+export function cleanErrors() {
+  return (dispatch) => {
+    dispatch({
+      type: CLEAN_ERRORS,
+    });
+  };
+}

--- a/client/src/actions/error.js
+++ b/client/src/actions/error.js
@@ -2,11 +2,15 @@ export const ADD_ERROR = "ADD_ERROR";
 export const REMOVE_ERROR = "REMOVE_ERROR";
 export const CLEAN_ERRORS = "CLEAN_ERRORS";
 
-export function addError(error) {
+export function addError(code, message = "Server Error") {
   return (dispatch) => {
     dispatch({
       type: ADD_ERROR,
-      error,
+      error: {
+        pathname: window.location.pathname,
+        code,
+        message,
+      },
     });
   };
 }

--- a/client/src/actions/project.js
+++ b/client/src/actions/project.js
@@ -2,6 +2,7 @@ import cookie from "react-cookies";
 
 import { API_HOST } from "../config/settings";
 import { FETCH_ALL_CHARTS } from "./chart";
+import { addError } from "./error";
 
 export const FETCHING_ALL_PROJECTS = "FETCHING_ALL_PROJECTS";
 export const FETCHING_PROJECT = "FETCHING_PROJECT";
@@ -26,6 +27,7 @@ export function getAllProjects() {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -57,6 +59,7 @@ export function getProject(id, active) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -100,6 +103,7 @@ export function createProject(data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -135,6 +139,7 @@ export function updateProject(projectId, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -165,6 +170,7 @@ export function removeProject(projectId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.status));
         }
 
@@ -183,7 +189,7 @@ export function removeProject(projectId) {
 }
 
 export function getPublicDashboard(brewName) {
-  return () => {
+  return (dispatch) => {
     const token = cookie.load("brewToken");
     const url = `${API_HOST}/project/dashboard/${brewName}`;
     const headers = new Headers({
@@ -195,6 +201,7 @@ export function getPublicDashboard(brewName) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 

--- a/client/src/actions/savedQuery.js
+++ b/client/src/actions/savedQuery.js
@@ -1,5 +1,7 @@
 import cookie from "react-cookies";
+
 import { API_HOST } from "../config/settings";
+import { addError } from "./error";
 
 export const FETCHING_QUERY = "FETCHING_QUERY";
 export const FETCH_QUERY_FAIL = "FETCH_QUERY_FAIL";
@@ -19,6 +21,7 @@ export function getSavedQueries(projectId, type) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error(response.status);
         }
 
@@ -49,6 +52,7 @@ export function createSavedQuery(projectId, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error(response.status);
         }
 
@@ -79,6 +83,7 @@ export function updateSavedQuery(projectId, savedQueryId, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error(response.status);
         }
 
@@ -107,6 +112,7 @@ export function deleteSavedQuery(projectId, savedQueryId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error(response.status);
         }
 

--- a/client/src/actions/team.js
+++ b/client/src/actions/team.js
@@ -1,6 +1,7 @@
 import cookie from "react-cookies";
 import { API_HOST } from "../config/settings";
 import { removeTeamInvite, saveTeamInvites } from "./user";
+import { addError } from "./error";
 
 export const SAVE_ACTIVE_TEAM = "SAVE_ACTIVE_TEAM";
 export const ADD_TEAM = "ADD_TEAM";
@@ -46,6 +47,7 @@ export function getTeams(userId) {
     return fetch(`${API_HOST}/team/user/${userId}`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -75,6 +77,7 @@ export function getTeam(teamId) {
     return fetch(`${API_HOST}/team/${teamId}`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -102,6 +105,7 @@ export function createTeam(userId, name) {
     return fetch(`${API_HOST}/team`, { method: "POST", headers, body })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -135,6 +139,7 @@ export function updateTeam(teamId, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -151,7 +156,7 @@ export function updateTeam(teamId, data) {
 }
 
 export function inviteMembers(userId, email, teamId) {
-  return () => {
+  return (dispatch) => {
     if (!cookie.load("brewToken")) {
       return new Promise((resolve, reject) => reject(new Error("No Token")));
     }
@@ -168,6 +173,7 @@ export function inviteMembers(userId, email, teamId) {
     return fetch(`${API_HOST}/team/${teamId}/invite`, { method: "POST", headers, body })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -198,6 +204,7 @@ export function addTeamMember(userId, inviteToken) {
     return fetch(`${API_HOST}/team/user/${userId}`, { method: "POST", headers, body })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -227,6 +234,7 @@ export function getTeamMembers(teamId) {
     return fetch(`${API_HOST}/team/${teamId}/members`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -259,6 +267,7 @@ export function updateTeamRole(role, memberId, teamId) {
     return fetch(`${API_HOST}/team/${teamId}/role`, { method: "PUT", headers, body })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -274,7 +283,7 @@ export function updateTeamRole(role, memberId, teamId) {
 }
 
 export function deleteTeamMember(memberId, teamId) {
-  return () => {
+  return (dispatch) => {
     if (!cookie.load("brewToken")) {
       return new Promise((resolve, reject) => reject(new Error("No Token")));
     }
@@ -290,6 +299,7 @@ export function deleteTeamMember(memberId, teamId) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -321,6 +331,7 @@ export function declineTeamInvite(teamId, inviteToken) {
     return fetch(`${API_HOST}/team/${teamId}/declineInvite/user`, { method: "POST", headers, body })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -337,7 +348,7 @@ export function declineTeamInvite(teamId, inviteToken) {
 }
 
 export function getUserByTeamInvite(token) {
-  return () => {
+  return (dispatch) => {
     const headers = new Headers({
       "Accept": "application/json",
       "Content-Type": "application/json",
@@ -345,6 +356,7 @@ export function getUserByTeamInvite(token) {
     return fetch(`${API_HOST}/team/invite/${token}`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -372,6 +384,7 @@ export function getTeamInvites(teamId) {
     return fetch(`${API_HOST}/team/pendingInvites/${teamId}`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -387,7 +400,7 @@ export function getTeamInvites(teamId) {
 }
 
 export function resendTeamInvite(invite) {
-  return () => {
+  return (dispatch) => {
     if (!cookie.load("brewToken")) {
       return new Promise((resolve, reject) => reject(new Error("No Token")));
     }
@@ -403,6 +416,7 @@ export function resendTeamInvite(invite) {
     return fetch(`${API_HOST}/team/resendInvite`, { method: "POST", body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();

--- a/client/src/actions/user.js
+++ b/client/src/actions/user.js
@@ -74,6 +74,14 @@ export function createUser(data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch({
+            type: ADD_ERROR,
+            error: {
+              pathname: window.location.pathname,
+              code: response.status,
+              message: "Server Error",
+            },
+          });
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -196,6 +204,11 @@ export function createInvitedUser(data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch({
+            pathname: window.location.pathname,
+            code: response.status,
+            message: "Server Error",
+          });
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();

--- a/client/src/actions/user.js
+++ b/client/src/actions/user.js
@@ -1,6 +1,6 @@
 import cookie from "react-cookies";
 import { API_HOST } from "../config/settings";
-import { ADD_ERROR } from "./error";
+import { addError } from "./error";
 
 export const SAVE_USER = "SAVE_USER";
 export const LOGOUT_USER = "LOGOUT_USER";
@@ -74,14 +74,7 @@ export function createUser(data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
-          dispatch({
-            type: ADD_ERROR,
-            error: {
-              pathname: window.location.pathname,
-              code: response.status,
-              message: "Server Error",
-            },
-          });
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -103,7 +96,7 @@ export function createUser(data) {
 }
 
 export function addEmailToList(email) {
-  return () => {
+  return (dispatch) => {
     const url = `${API_HOST}/user/email`;
     const body = JSON.stringify({ email });
     const headers = new Headers({
@@ -115,6 +108,7 @@ export function addEmailToList(email) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -145,6 +139,7 @@ export function updateUser(id, data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
 
@@ -176,6 +171,7 @@ export function deleteUser(id) {
     return fetch(url, { method, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -204,11 +200,7 @@ export function createInvitedUser(data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
-          dispatch({
-            pathname: window.location.pathname,
-            code: response.status,
-            message: "Server Error",
-          });
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -235,6 +227,7 @@ export function verify(id, token) {
     return fetch(`${API_HOST}/user/${id}/verify`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error("Could not verify email.");
         }
 
@@ -263,14 +256,7 @@ export function login(data) {
     return fetch(`${API_HOST}/user/login`, { method: "POST", headers, body })
       .then((response) => {
         if (!response.ok) {
-          dispatch({
-            type: ADD_ERROR,
-            error: {
-              pathname: window.location.pathname,
-              code: response.status,
-              message: "Couldn't login",
-            },
-          });
+          dispatch(addError(response.status, "Couldn't login"));
           throw new Error("Couldn't login");
         }
         return response.json();
@@ -290,7 +276,7 @@ export function login(data) {
 
 export function relog() {
   const token = cookie.load("brewToken");
-  return () => {
+  return (dispatch) => {
     if (!token) {
       if (authenticatePage()) {
         window.location.pathname = "/login";
@@ -309,6 +295,7 @@ export function relog() {
     return fetch(url, { method, headers })
       .then(response => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject("Couldn't relog"));
         }
         return response.json();
@@ -335,6 +322,7 @@ export function getUser(id) {
     return fetch(`${API_HOST}/user/${id}`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status, "Couldn't get requested user"));
           throw new Error("Couldn't get requested user");
         }
         return response.json();
@@ -364,6 +352,7 @@ export function getPendingInvites(id) {
     return fetch(`${API_HOST}/user/${id}/teamInvites`, { method: "GET", headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -387,7 +376,7 @@ export function logout() {
 }
 
 export function sendFeedback({ name, feedback, email }) {
-  return () => {
+  return (dispatch) => {
     const body = JSON.stringify({
       "from": name,
       "email": email,
@@ -400,6 +389,7 @@ export function sendFeedback({ name, feedback, email }) {
     return fetch(`${API_HOST}/user/feedback`, { method: "POST", body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.statusText));
         }
         return response.json();
@@ -414,7 +404,7 @@ export function sendFeedback({ name, feedback, email }) {
 }
 
 export function requestPasswordReset(email) {
-  return () => {
+  return (dispatch) => {
     const url = `${API_HOST}/user/password/reset`;
     const method = "POST";
     const body = JSON.stringify({ email });
@@ -426,6 +416,7 @@ export function requestPasswordReset(email) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           throw new Error(response.status);
         }
       })
@@ -439,7 +430,7 @@ export function requestPasswordReset(email) {
 }
 
 export function changePasswordWithToken(data) {
-  return () => {
+  return (dispatch) => {
     const url = `${API_HOST}/user/password/change`;
     const method = "PUT";
     const headers = new Headers({
@@ -451,6 +442,7 @@ export function changePasswordWithToken(data) {
     return fetch(url, { method, body, headers })
       .then((response) => {
         if (!response.ok) {
+          dispatch(addError(response.status));
           return new Promise((resolve, reject) => reject(response.status));
         }
 

--- a/client/src/actions/user.js
+++ b/client/src/actions/user.js
@@ -1,5 +1,6 @@
 import cookie from "react-cookies";
 import { API_HOST } from "../config/settings";
+import { ADD_ERROR } from "./error";
 
 export const SAVE_USER = "SAVE_USER";
 export const LOGOUT_USER = "LOGOUT_USER";
@@ -249,6 +250,14 @@ export function login(data) {
     return fetch(`${API_HOST}/user/login`, { method: "POST", headers, body })
       .then((response) => {
         if (!response.ok) {
+          dispatch({
+            type: ADD_ERROR,
+            error: {
+              pathname: window.location.pathname,
+              code: response.status,
+              message: "Couldn't login",
+            },
+          });
           throw new Error("Couldn't login");
         }
         return response.json();

--- a/client/src/components/LoginForm.js
+++ b/client/src/components/LoginForm.js
@@ -21,7 +21,6 @@ class LoginForm extends Component {
     this.loginUser = this.loginUser.bind(this);
     this.state = {
       loading: false,
-      loginError: false,
     };
   }
 
@@ -65,8 +64,8 @@ class LoginForm extends Component {
       }
       this.setState({ loading: false });
       history.push("/user");
-    }).catch((err) => {
-      this.setState({ loginError: true, loading: false, errorMessage: err });
+    }).catch(() => {
+      this.setState({ loading: false });
     });
   }
 
@@ -92,7 +91,7 @@ class LoginForm extends Component {
   render() {
     const { handleSubmit } = this.props;
     const {
-      loading, loginError, errorMessage, forgotModal, resetSuccess, resetError,
+      loading, forgotModal, resetSuccess, resetError,
       resetLoading,
     } = this.state;
     return (
@@ -122,13 +121,6 @@ class LoginForm extends Component {
           >
             <a href="#">Forgot password?</a>
           </Item>
-          {loginError
-          && (
-          <Message negative>
-            <Message.Header>{errorMessage}</Message.Header>
-            <p>Please try it again.</p>
-          </Message>
-          )}
         </Form>
         {/*
           <Divider horizontal> Or </Divider>

--- a/client/src/containers/AddChart.js
+++ b/client/src/containers/AddChart.js
@@ -17,6 +17,7 @@ import "chart.piecelabel.js";
 import {
   testQuery, createChart, runQuery, updateChart, getPreviewData
 } from "../actions/chart";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import ChartTypesSelector from "../components/ChartTypesSelector";
 import ObjectExplorer from "../components/ObjectExplorer";
 import ChartBuilder from "../components/ChartBuilder";
@@ -52,6 +53,8 @@ class AddChart extends Component {
   }
 
   componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
     this._populateConnections();
   }
 
@@ -1111,6 +1114,7 @@ AddChart.propTypes = {
   match: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
   charts: PropTypes.array.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -1128,6 +1132,7 @@ const mapDispatchToProps = (dispatch) => {
     runQuery: (projectId, chartId) => dispatch(runQuery(projectId, chartId)),
     updateChart: (projectId, chartId, data) => dispatch(updateChart(projectId, chartId, data)),
     getPreviewData: (projectId, chart) => dispatch(getPreviewData(projectId, chart)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/Connections.js
+++ b/client/src/containers/Connections.js
@@ -14,6 +14,7 @@ import MysqlConnectionForm from "../components/MysqlConnectionForm";
 import {
   testConnection, updateConnection, removeConnection, getProjectConnections
 } from "../actions/connection";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import mongoLogo from "../assets/mongodb-logo-1.png";
 import canAccess from "../config/canAccess";
 import mysql from "../assets/mysql.svg";
@@ -31,6 +32,11 @@ class Connections extends Component {
     this.state = {
       testModal: false,
     };
+  }
+
+  componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
   }
 
   _testConnection = (id) => {
@@ -487,6 +493,7 @@ Connections.propTypes = {
   removeConnection: PropTypes.func.isRequired,
   getProjectConnections: PropTypes.func.isRequired,
   match: PropTypes.object.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -503,6 +510,7 @@ const mapDispatchToProps = (dispatch) => {
     updateConnection: (projectId, id, data) => dispatch(updateConnection(projectId, id, data)),
     removeConnection: (projectId, id) => dispatch(removeConnection(projectId, id)),
     getProjectConnections: (projectId) => dispatch(getProjectConnections(projectId)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/Login.js
+++ b/client/src/containers/Login.js
@@ -1,11 +1,14 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import {
   Message, Container, Segment, Header
 } from "semantic-ui-react";
+import _ from "lodash";
 
 import LoginForm from "../components/LoginForm";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import { blue } from "../config/colors";
 import cbLogoSmall from "../assets/cb_logo_4_small_inverted.png";
 
@@ -13,7 +16,15 @@ import cbLogoSmall from "../assets/cb_logo_4_small_inverted.png";
   Login container with an embedded login form
 */
 class Login extends Component {
+  componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
+  }
+
   render() {
+    const { errors } = this.props;
+    const loginError = _.find(errors, { pathname: window.location.pathname });
+
     return (
       <div style={styles.container}>
         <Container text textAlign="center">
@@ -23,11 +34,16 @@ class Login extends Component {
           <Header inverted as="h2" style={{ marginTop: 0 }}>Login to your account</Header>
           <Segment raised>
             <LoginForm />
+            {loginError && (
+              <Message negative>
+                <Message.Header>{loginError.message}</Message.Header>
+                <p>Please try it again.</p>
+              </Message>
+            )}
           </Segment>
           <Message>
-            {" You don't have an account yet?"}
+            {" You don't have an account yet? "}
             <Link to={"/signup"}>Sign Up</Link>
-            {" "}
           </Message>
         </Container>
       </div>
@@ -45,15 +61,19 @@ const styles = {
 };
 
 Login.propTypes = {
+  errors: PropTypes.array.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = () => {
+const mapStateToProps = (state) => {
   return {
+    errors: state.error,
   };
 };
 
-const mapDispatchToProps = () => {
+const mapDispatchToProps = (dispatch) => {
   return {
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/Main.js
+++ b/client/src/containers/Main.js
@@ -20,15 +20,18 @@ import EmbeddedChart from "./EmbeddedChart";
 import { relog, getUser } from "../actions/user";
 import { getTeams } from "../actions/team";
 import { getAllProjects } from "../actions/project";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
+
 /*
   Description
 */
 class Main extends Component {
   componentDidMount() {
     const {
-      relog, getUser, getTeams, getAllProjects, location,
+      relog, getUser, getTeams, getAllProjects, location, cleanErrors,
     } = this.props;
 
+    cleanErrors();
     if (!location.pathname.match(/\/chart\/\d+\/embedded/g)) {
       relog().then((data) => {
         getUser(data.id);
@@ -96,7 +99,7 @@ Main.propTypes = {
   getTeams: PropTypes.func.isRequired,
   getAllProjects: PropTypes.func.isRequired,
   location: PropTypes.object.isRequired,
-  // user: PropTypes.object.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -111,6 +114,7 @@ const mapDispatchToProps = (dispatch) => {
     getUser: (id) => dispatch(getUser(id)),
     getAllProjects: () => dispatch(getAllProjects()),
     getTeams: (id) => dispatch(getTeams(id)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/ManageTeam.js
+++ b/client/src/containers/ManageTeam.js
@@ -10,6 +10,7 @@ import {
 } from "semantic-ui-react";
 
 import { getTeam, saveActiveTeam } from "../actions/team";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import TeamMembers from "./TeamMembers";
 import TeamSettings from "./TeamSettings";
 import Navbar from "../components/Navbar";
@@ -28,6 +29,8 @@ class ManageTeam extends Component {
   }
 
   componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
     this._getTeam();
   }
 
@@ -136,6 +139,7 @@ ManageTeam.propTypes = {
   user: PropTypes.object.isRequired,
   match: PropTypes.object.isRequired,
   saveActiveTeam: PropTypes.func.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -149,6 +153,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     getTeam: id => dispatch(getTeam(id)),
     saveActiveTeam: (team) => dispatch(saveActiveTeam(team)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/ManageUser.js
+++ b/client/src/containers/ManageUser.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import PropTypes from "prop-types";
 import { Route, Switch, withRouter } from "react-router";
 
 import { Link } from "react-router-dom";
@@ -7,10 +8,17 @@ import { Link } from "react-router-dom";
 import { Menu, Header, Grid } from "semantic-ui-react";
 import EditUserForm from "../components/EditUserForm";
 import Navbar from "../components/Navbar";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
+
 /*
   Component for inviting user to the team
 */
 class ManageUser extends Component {
+  componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
+  }
+
   check(path) {
     switch (path) {
       case "edit":
@@ -66,6 +74,7 @@ const styles = {
 };
 
 ManageUser.propTypes = {
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -74,8 +83,9 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = () => {
+const mapDispatchToProps = (dispatch) => {
   return {
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/PasswordReset.js
+++ b/client/src/containers/PasswordReset.js
@@ -8,6 +8,7 @@ import {
 } from "semantic-ui-react";
 
 import { changePasswordWithToken } from "../actions/user";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import { blue } from "../config/colors";
 import cbLogoSmall from "../assets/cb_logo_4_small_inverted.png";
 
@@ -23,6 +24,11 @@ class PasswordReset extends Component {
       success: false,
       error: false,
     };
+  }
+
+  componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
   }
 
   _onSubmit = () => {
@@ -143,6 +149,7 @@ const styles = {
 PasswordReset.propTypes = {
   changePasswordWithToken: PropTypes.func.isRequired,
   history: PropTypes.object.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = () => {
@@ -153,6 +160,7 @@ const mapStateToProps = () => {
 const mapDispatchToProps = (dispatch) => {
   return {
     changePasswordWithToken: (data) => dispatch(changePasswordWithToken(data)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/ProjectBoard.js
+++ b/client/src/containers/ProjectBoard.js
@@ -10,6 +10,7 @@ import {
 import SplitPane from "react-split-pane";
 
 import { getProject, changeActiveProject } from "../actions/project";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import { getTeam } from "../actions/team";
 import { getProjectCharts } from "../actions/chart";
 import { getProjectConnections } from "../actions/connection";
@@ -40,6 +41,8 @@ class ProjectBoard extends Component {
   }
 
   componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
     this._init();
     if (window.localStorage.getItem("_cb_menu_size")) {
       this._setMenuSize(window.localStorage.getItem("_cb_menu_size"), true);
@@ -470,6 +473,7 @@ ProjectBoard.propTypes = {
   getProjectCharts: PropTypes.func.isRequired,
   getProjectConnections: PropTypes.func.isRequired,
   getTeam: PropTypes.func.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -488,6 +492,7 @@ const mapDispatchToProps = (dispatch) => {
     getProjectCharts: (projectId) => dispatch(getProjectCharts(projectId)),
     getProjectConnections: (projectId) => dispatch(getProjectConnections(projectId)),
     getTeam: (teamId) => dispatch(getTeam(teamId)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/ProjectDashboard.js
+++ b/client/src/containers/ProjectDashboard.js
@@ -7,11 +7,17 @@ import {
 import { Link } from "react-router-dom";
 
 import Chart from "./Chart";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import dashboardImage from "../assets/290.png";
 /*
   Description
 */
 class ProjectDashboard extends Component {
+  componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
+  }
+
   render() {
     const { connections, charts, match } = this.props;
 
@@ -41,7 +47,7 @@ class ProjectDashboard extends Component {
             <Header size="huge" textAlign="center">
               <span role="img" aria-label="wave">👋</span>
               {" "}
-Welcome to Chart Brew
+              Welcome to Chart Brew
               <Header.Subheader>
                 {"Why not jump right into it? Create a new database connection and start visualizing your data. "}
               </Header.Subheader>
@@ -61,6 +67,7 @@ Welcome to Chart Brew
     );
   }
 }
+
 const styles = {
   container: {
     flex: 1,
@@ -73,6 +80,7 @@ ProjectDashboard.propTypes = {
   connections: PropTypes.array.isRequired,
   charts: PropTypes.array.isRequired,
   match: PropTypes.object.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -82,8 +90,9 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = () => {
+const mapDispatchToProps = (dispatch) => {
   return {
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 export default connect(mapStateToProps, mapDispatchToProps)(ProjectDashboard);

--- a/client/src/containers/ProjectSettings.js
+++ b/client/src/containers/ProjectSettings.js
@@ -8,6 +8,7 @@ import {
 
 import canAccess from "../config/canAccess";
 import { updateProject, changeActiveProject, removeProject } from "../actions/project";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 
 const queryString = require("qs"); // eslint-disable-line
 /*
@@ -21,6 +22,11 @@ class ProjectSettings extends Component {
       success: false,
       error: false,
     };
+  }
+
+  componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
   }
 
   _onSaveName = () => {
@@ -184,6 +190,7 @@ ProjectSettings.propTypes = {
   updateProject: PropTypes.func.isRequired,
   changeActiveProject: PropTypes.func.isRequired,
   removeProject: PropTypes.func.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -199,6 +206,7 @@ const mapDispatchToProps = (dispatch) => {
     updateProject: (projectId, data) => dispatch(updateProject(projectId, data)),
     changeActiveProject: (projectId) => dispatch(changeActiveProject(projectId)),
     removeProject: (projectId) => dispatch(removeProject(projectId)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/PublicDashboard.js
+++ b/client/src/containers/PublicDashboard.js
@@ -8,6 +8,7 @@ import {
 } from "semantic-ui-react";
 
 import { getPublicDashboard } from "../actions/project";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import Chart from "./Chart";
 import { blue } from "../config/colors";
 import cbLogo from "../assets/cb_logo_4_small_inverted.png";
@@ -26,7 +27,8 @@ class PublicDashboard extends Component {
   }
 
   componentDidMount() {
-    const { getPublicDashboard, match } = this.props;
+    const { getPublicDashboard, match, cleanErrors } = this.props;
+    cleanErrors();
     getPublicDashboard(match.params.brewName)
       .then((dashboard) => {
         this.setState({ dashboard, loading: false });
@@ -140,6 +142,7 @@ const styles = {
 PublicDashboard.propTypes = {
   getPublicDashboard: PropTypes.func.isRequired,
   match: PropTypes.object.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = () => {
@@ -150,6 +153,7 @@ const mapStateToProps = () => {
 const mapDispatchToProps = (dispatch) => {
   return {
     getPublicDashboard: (brewName) => dispatch(getPublicDashboard(brewName)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/PublicDashboardEditor.js
+++ b/client/src/containers/PublicDashboardEditor.js
@@ -9,6 +9,8 @@ import {
 
 import Chart from "./Chart";
 import { updateProject, changeActiveProject } from "../actions/project";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
+
 /*
   Description
 */
@@ -23,6 +25,8 @@ class PublicDashboardEditor extends Component {
   }
 
   componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
     this._checkIfNoPublic();
   }
 
@@ -179,6 +183,7 @@ PublicDashboardEditor.propTypes = {
   match: PropTypes.object.isRequired,
   updateProject: PropTypes.func.isRequired,
   changeActiveProject: PropTypes.func.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -192,6 +197,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     updateProject: (projectId, data) => dispatch(updateProject(projectId, data)),
     changeActiveProject: (projectId) => dispatch(changeActiveProject(projectId)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/Signup.js
+++ b/client/src/containers/Signup.js
@@ -6,12 +6,14 @@ import { Link } from "react-router-dom";
 import {
   Message, Divider, Container, Segment, Form, Button, Header, Icon, Label,
 } from "semantic-ui-react";
+import _ from "lodash";
 
 import { createUser, createInvitedUser } from "../actions/user";
 import { addTeamMember } from "../actions/team";
 import { required, email } from "../config/validations";
 import cbLogoSmall from "../assets/cb_logo_4_small_inverted.png";
 import { blue } from "../config/colors";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 
 const queryString = require("qs"); // eslint-disable-line
 /*
@@ -24,6 +26,11 @@ class Signup extends Component {
     this.state = {
       loading: false,
     };
+  }
+
+  componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
   }
 
   submitUser = (values) => {
@@ -40,8 +47,8 @@ class Signup extends Component {
 
           history.push("/user");
         })
-        .catch((err) => {
-          this.setState({ signupError: true, loading: false, errorMessage: err.message });
+        .catch(() => {
+          this.setState({ loading: false });
         });
     }
   }
@@ -59,8 +66,8 @@ class Signup extends Component {
             }, 3000);
           });
       })
-      .catch((err) => {
-        this.setState({ signupError: true, loading: false, errorMessage: err.message });
+      .catch(() => {
+        this.setState({ loading: false });
       });
   }
 
@@ -106,10 +113,12 @@ class Signup extends Component {
   }
 
   render() {
-    const { handleSubmit } = this.props;
+    const { handleSubmit, errors } = this.props;
     const {
-      loading, signupError, errorMessage, addedToTeam,
+      loading, addedToTeam,
     } = this.state;
+
+    const signupError = _.find(errors, { pathname: window.location.pathname });
 
     return (
       <div style={styles.container}>
@@ -154,7 +163,7 @@ class Signup extends Component {
               {signupError
               && (
               <Message negative>
-                <Message.Header>{errorMessage}</Message.Header>
+                <Message.Header>{signupError.message}</Message.Header>
                 <p>Please try it again.</p>
               </Message>
               )}
@@ -209,12 +218,15 @@ Signup.propTypes = {
   createInvitedUser: PropTypes.func.isRequired,
   history: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,
+  errors: PropTypes.array.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
   return {
     form: state.forms,
     user: state.user.data,
+    errors: state.error,
   };
 };
 
@@ -223,6 +235,7 @@ const mapDispatchToProps = (dispatch) => {
     createUser: user => dispatch(createUser(user)),
     addTeamMember: (userId, token) => dispatch(addTeamMember(userId, token)),
     createInvitedUser: user => dispatch(createInvitedUser(user)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 export default reduxForm({ form: "signup", validate })(connect(mapStateToProps, mapDispatchToProps)(Signup));

--- a/client/src/containers/TeamMembers.js
+++ b/client/src/containers/TeamMembers.js
@@ -9,6 +9,7 @@ import {
 import {
   getTeam, getTeamMembers, updateTeamRole, deleteTeamMember
 } from "../actions/team";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import Invites from "../components/Invites";
 import InviteMembersForm from "../components/InviteMembersForm";
 import canAccess from "../config/canAccess";
@@ -28,6 +29,8 @@ class TeamMembers extends Component {
   }
 
   componentDidMount() {
+    const { cleanErrors } = this.props;
+    cleanErrors();
     this._getTeam();
   }
 
@@ -287,6 +290,7 @@ TeamMembers.propTypes = {
   getTeamMembers: PropTypes.func.isRequired,
   updateTeamRole: PropTypes.func.isRequired,
   deleteTeamMember: PropTypes.func.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -303,6 +307,7 @@ const mapDispatchToProps = (dispatch) => {
     getTeamMembers: teamId => dispatch(getTeamMembers(teamId)),
     updateTeamRole: (role, memberId, teamId) => dispatch(updateTeamRole(role, memberId, teamId)),
     deleteTeamMember: (memberId, teamId) => dispatch(deleteTeamMember(memberId, teamId)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/TeamSettings.js
+++ b/client/src/containers/TeamSettings.js
@@ -6,6 +6,7 @@ import {
   Dimmer, Segment, Loader, Divider, Message, Icon, Form, Container, Header
 } from "semantic-ui-react";
 import { getTeam, updateTeam } from "../actions/team";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 
 /*
   Contains team update functionality
@@ -25,7 +26,8 @@ class TeamSettings extends Component {
   }
 
   componentDidMount() {
-    const { getTeam, match } = this.props;
+    const { getTeam, match, cleanErrors } = this.props;
+    cleanErrors();
     getTeam(match.params.teamId)
       .then((team) => {
         this.setState({ teamState: { name: team.name } });
@@ -121,6 +123,7 @@ TeamSettings.propTypes = {
   match: PropTypes.object.isRequired,
   updateTeam: PropTypes.func.isRequired,
   style: PropTypes.object,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -133,6 +136,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     getTeam: id => dispatch(getTeam(id)),
     updateTeam: (teamId, data) => dispatch(updateTeam(teamId, data)),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/containers/UserDashboard.js
+++ b/client/src/containers/UserDashboard.js
@@ -9,6 +9,7 @@ import {
 
 import { getTeams, createTeam, saveActiveTeam } from "../actions/team";
 import { getUser, relog as relogAction } from "../actions/user";
+import { cleanErrors as cleanErrorsAction } from "../actions/error";
 import ProjectForm from "../components/ProjectForm";
 import InviteMembersForm from "../components/InviteMembersForm";
 import Invites from "../components/Invites";
@@ -35,7 +36,8 @@ class UserDashboard extends Component {
   }
 
   componentDidMount() {
-    const { relog } = this.props;
+    const { relog, cleanErrors } = this.props;
+    cleanErrors();
     relog();
     this._getTeams();
   }
@@ -339,6 +341,7 @@ UserDashboard.propTypes = {
   saveActiveTeam: PropTypes.func.isRequired,
   history: PropTypes.object.isRequired,
   relog: PropTypes.func.isRequired,
+  cleanErrors: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -355,6 +358,7 @@ const mapDispatchToProps = (dispatch) => {
     createTeam: (userId, name) => dispatch(createTeam(userId, name)),
     saveActiveTeam: (team) => dispatch(saveActiveTeam(team)),
     relog: () => dispatch(relogAction()),
+    cleanErrors: () => dispatch(cleanErrorsAction()),
   };
 };
 

--- a/client/src/reducers/error.js
+++ b/client/src/reducers/error.js
@@ -1,0 +1,20 @@
+import {
+  ADD_ERROR,
+  REMOVE_ERROR,
+  CLEAN_ERRORS,
+} from "../actions/error";
+
+const initialState = [];
+
+export default function error(state = initialState, action) {
+  switch (action.type) {
+    case ADD_ERROR:
+      return [action.error, ...state];
+    case REMOVE_ERROR:
+      return state.filter((error, i) => i !== action.index);
+    case CLEAN_ERRORS:
+      return state.filter((i) => i.pathname !== window.location.pathname);
+    default:
+      return state;
+  }
+}

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -9,6 +9,7 @@ import team from "./team";
 import chart from "./chart";
 import connection from "./connection";
 import savedQuery from "./savedQuery";
+import error from "./error";
 
 const AppReducer = combineReducers({
   user,
@@ -18,6 +19,7 @@ const AppReducer = combineReducers({
   chart,
   connection,
   savedQuery,
+  error,
   route: routerReducer,
 });
 


### PR DESCRIPTION
**:building_construction: Architectural change**

Currently, error handling is a bit messy in the client as it doesn't really follow any guidelines.

### The plan

* New error reducer - save the errors in the store
* The errors will have the following format:

```
{
  pathname: "/login",
  code: "404",
  message: "Wrong username or password"
}
```

* The containers will do all the error displaying (will use the error store)
* The containers will refresh all its errors on `mount`
* Can add, remove, clean errors using actions
* All `fetch` errors will use the `ADD_ERROR` action instead of simply throwing errors